### PR TITLE
Add CI tools docker image pipeline

### DIFF
--- a/.github/workflows/ci-docker-tools.yml
+++ b/.github/workflows/ci-docker-tools.yml
@@ -5,6 +5,9 @@ name: Docker - CI tooling for GitHub Actions
 # is modified, and on a weekly schedule to get updates.
 
 on:
+  pull_request:
+    paths:
+      - 'docker/tools/**'
   push:
     paths:
       - 'docker/tools/**'
@@ -12,7 +15,14 @@ on:
       - 'master'
   schedule:
     - cron: '0 0 * * 1' # Run every Monday at 12:00 AM UTC
-  pull_request:
+
+# Make sure to cancel previous job runs in case a PR
+# gets new commits. Changes being merged to the main
+# branch will continue to run.
+
+concurrency:
+  group: ${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
   tools-latest:

--- a/.github/workflows/ci-docker-tools.yml
+++ b/.github/workflows/ci-docker-tools.yml
@@ -1,0 +1,44 @@
+name: Docker - CI tooling for GitHub Actions
+
+# This workflow builds the CI tooling from docker/tools/
+# within this repository. It runs whenever a file inside
+# is modified, and on a weekly schedule to get updates.
+
+on:
+  push:
+    paths:
+      - 'docker/tools/**'
+    branches:
+      - 'master'
+  schedule:
+    - cron: '0 0 * * 1' # Run every Monday at 12:00 AM UTC
+  pull_request:
+
+jobs:
+  tools-latest:
+    name: 'Build tykio/ci-tools:${{ matrix.tag }}'
+    strategy:
+      fail-fast: false
+      matrix:
+        tag:
+          - 'latest'
+
+    runs-on: ubuntu-latest
+ 
+    steps:
+    - uses: actions/checkout@v3
+    - uses: docker/setup-buildx-action@v2
+    - uses: docker/login-action@v2
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+            
+    - name: 'Build tykio/ci-tools:latest'
+      uses: docker/build-push-action@v4
+      with:
+        push: ${{ github.ref_name == 'main' }}
+        pull: true
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
+        context: docker/tools/latest
+        tags: tykio/ci-tools:latest

--- a/docker/tools/Taskfile.yml
+++ b/docker/tools/Taskfile.yml
@@ -1,0 +1,19 @@
+---
+version: "3"
+
+vars:
+  platform: '{{.BUILD_PLATFORM | default "linux/amd64"}}'
+
+env:
+  DOCKER_BUILDKIT: 1
+  BUILDX_EXPERIMENTAL: 1
+
+tasks:
+  default:
+    desc: "Build docker images"
+    vars:
+      tags: latest
+      args: --rm --platform {{.platform}}
+    cmds:
+      - for: { var: tags, as: tag }
+        cmd: docker build -t internal/tools:{{.tag}} -f {{.tag}}/Dockerfile {{.tag}}/

--- a/docker/tools/latest/Dockerfile
+++ b/docker/tools/latest/Dockerfile
@@ -1,0 +1,34 @@
+FROM golang:1.20 AS tools-build
+
+ENV CGO_ENABLED=0
+ENV GOBIN=/usr/local/bin
+WORKDIR /usr/local/bin
+
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/TykTechnologies/exp/cmd/schema-gen@main
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/TykTechnologies/exp/cmd/go-fsck@main
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/golang/mock/mockgen@v1.6.0
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install golang.org/x/tools/cmd/goimports@latest
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/golangci/golangci-lint/cmd/golangci-lint@v1.45.0
+RUN --mount=type=cache,mode=0755,target=/go/pkg/mod go install github.com/fatih/faillint@latest
+
+ARG TASK_VERSION=v3.27.1
+RUN curl -sSL https://github.com/go-task/task/releases/download/${TASK_VERSION}/task_linux_amd64.tar.gz | tar -zxv
+
+# Final tools image
+#
+# This uses the `scratch` as the image base. The image
+# doesn't need a base OS, as it's intended to be used
+# in CI pipelines that do. Example action:
+#
+# ```
+# - uses: shrink/actions-docker-extract@v3
+#   with:
+#     image: <tools>
+#     path: /usr/local/bin/.
+#     destination: /usr/local/bin
+# ```
+#
+# https://github.com/marketplace/actions/docker-extract
+
+FROM scratch
+COPY --from=tools-build /usr/local/bin/ /usr/local/bin/


### PR DESCRIPTION
This PR adds a dockerfile for the CI tooling in use at tyk, and a github actions workflow that builds the tooling on any change within `docker/tools/*`, and scheduled every monday.

It also adds a local build taskfile that produces `internal/ci-tools` image.

The images published to docker hub are named `tykio/ci-tools`. Currently only the `latest` tag is being provided.