### PR TITLE
[TT-17030] Migrate remaining workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/dashboard-5.0.yml
+++ b/.github/workflows/dashboard-5.0.yml
@@ -5,9 +5,11 @@ name: Dashboard 5.0 tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "5.0"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "5.0"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dashboard-5.2.yml
+++ b/.github/workflows/dashboard-5.2.yml
@@ -5,9 +5,11 @@ name: Dashboard 5.2 tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "5.2"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "5.2"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/dashboard-latest.yml
+++ b/.github/workflows/dashboard-latest.yml
@@ -5,9 +5,11 @@ name: Dashboard latest tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "latest"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "latest"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/gateway-5.0.yml
+++ b/.github/workflows/gateway-5.0.yml
@@ -5,9 +5,11 @@ name: Gateway 5.0 tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "5.0"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "5.0"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/gateway-5.2.yml
+++ b/.github/workflows/gateway-5.2.yml
@@ -5,9 +5,11 @@ name: Gateway 5.2 tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "5.2"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "5.2"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/gateway-latest.yml
+++ b/.github/workflows/gateway-latest.yml
@@ -5,9 +5,11 @@ name: Gateway latest tests
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
 concurrency:
@@ -20,11 +22,13 @@ jobs:
     with:
       release: "latest"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
 
   test:
     uses: TykTechnologies/tyk-github-actions/.github/workflows/reuse-test.yml@main
     with:
       release: "latest"
     secrets:
-      ORG_GH_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+      PROBE_APP_ID: ${{ secrets.PROBE_APP_ID }}
+      PROBE_APP_PRIVATE_KEY: ${{ secrets.PROBE_APP_PRIVATE_KEY }}

--- a/.github/workflows/reuse-preflight.yml
+++ b/.github/workflows/reuse-preflight.yml
@@ -8,9 +8,11 @@ name: "Pre-flight checks"
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
     # Customize inputs from source repository invocation.
@@ -34,15 +36,23 @@ jobs:
     timeout-minutes: 10
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Use GitHub token"
         env:
-          TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: "Checkout repository"
         uses: TykTechnologies/tyk-github-actions/.github/actions/checkout@main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Configure Go Cache"
         uses: actions/cache@v3

--- a/.github/workflows/reuse-test.yml
+++ b/.github/workflows/reuse-test.yml
@@ -10,9 +10,11 @@ name: "Run go tests"
 on:  # yamllint disable-line rule:truthy
   workflow_call:
 
-    # Require ORG_GH_TOKEN to access private repositories.
+    # Require GitHub App credentials to generate tokens for private repositories.
     secrets:
-      ORG_GH_TOKEN:
+      PROBE_APP_ID:
+        required: true
+      PROBE_APP_PRIVATE_KEY:
         required: true
 
     # Customize inputs from source repository invocation.
@@ -56,15 +58,23 @@ jobs:
           --health-retries 5
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: "Use GitHub token"
         env:
-          TOKEN: ${{ secrets.ORG_GH_TOKEN }}
+          TOKEN: ${{ steps.app-token.outputs.token }}
         run: git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
 
       - name: "Checkout repository"
         uses: TykTechnologies/tyk-github-actions/.github/actions/checkout@main
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
 
       - name: "Configure Go Cache"
         uses: actions/cache@v3


### PR DESCRIPTION
## Summary
- Replace `ORG_GH_TOKEN` (PAT) with GitHub App token generation using `actions/create-github-app-token` across all 8 workflow files
- Reusable workflows (`reuse-preflight.yml`, `reuse-test.yml`) now declare `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` secrets instead of `ORG_GH_TOKEN`, and generate a short-lived app token as the first step in each job
- Caller workflows (`gateway-5.0.yml`, `gateway-5.2.yml`, `gateway-latest.yml`, `dashboard-5.0.yml`, `dashboard-5.2.yml`, `dashboard-latest.yml`) pass through the new secrets to the reusable workflows

## Files changed
- `.github/workflows/reuse-preflight.yml` — secrets declaration + app-token step + token replacement
- `.github/workflows/reuse-test.yml` — secrets declaration + app-token step + token replacement
- `.github/workflows/gateway-5.0.yml` — secrets declaration + secret passthrough
- `.github/workflows/gateway-5.2.yml` — secrets declaration + secret passthrough
- `.github/workflows/gateway-latest.yml` — secrets declaration + secret passthrough
- `.github/workflows/dashboard-5.0.yml` — secrets declaration + secret passthrough
- `.github/workflows/dashboard-5.2.yml` — secrets declaration + secret passthrough
- `.github/workflows/dashboard-latest.yml` — secrets declaration + secret passthrough

## Test plan
- [ ] Verify `PROBE_APP_ID` and `PROBE_APP_PRIVATE_KEY` org secrets are available to this repo
- [ ] Trigger a workflow run and confirm the GitHub App token is generated successfully
- [ ] Confirm private repository checkout and Go module fetching work with the new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)