### PR TITLE
[TT-17030] Fix git auth: use x-access-token prefix for GitHub App tokens

### DIFF
--- a/.github/workflows/reuse-preflight.yml
+++ b/.github/workflows/reuse-preflight.yml
@@ -47,7 +47,7 @@ jobs:
       - name: "Use GitHub token"
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: "Checkout repository"
         uses: TykTechnologies/tyk-github-actions/.github/actions/checkout@main

--- a/.github/workflows/reuse-test.yml
+++ b/.github/workflows/reuse-test.yml
@@ -69,7 +69,7 @@ jobs:
       - name: "Use GitHub token"
         env:
           TOKEN: ${{ steps.app-token.outputs.token }}
-        run: git config --global url."https://${TOKEN}@github.com".insteadOf "https://github.com"
+        run: git config --global url."https://x-access-token:${TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: "Checkout repository"
         uses: TykTechnologies/tyk-github-actions/.github/actions/checkout@main


### PR DESCRIPTION
## Summary
- Fix `git config insteadOf` pattern in `reuse-preflight.yml` and `reuse-test.yml` to use `x-access-token:` prefix and trailing slashes
- The bare token pattern fails when `actions/checkout` has set up a credential helper; the `x-access-token:` prefix ensures the URL rewrite takes precedence

## Files changed
- `.github/workflows/reuse-preflight.yml` — 1 replacement
- `.github/workflows/reuse-test.yml` — 1 replacement

## Test plan
- [ ] Verify reusable preflight workflow resolves private Go module deps
- [ ] Verify reusable test workflow resolves private Go module deps

🤖 Generated with [Claude Code](https://claude.com/claude-code)